### PR TITLE
Allow scholar.py to query multiple pages

### DIFF
--- a/scholar.py
+++ b/scholar.py
@@ -589,7 +589,7 @@ class SearchScholarQuery(ScholarQuery):
         self.author = None 
         self.pub = None
         self.timeframe = [None, None]
-        self.start = 0
+        self.start_index = 0
 
     def set_words(self, words):
         """Sets words that *all* must be found in the result."""
@@ -614,12 +614,12 @@ class SearchScholarQuery(ScholarQuery):
         """
         self.scope_title = title_only
 
-    def set_start(self, start_index):
+    def set_start_index(self, start_index):
         """
         Sets the start index of the query.  Usually, this would be a multiple
         of the size of the search result (probably 10 or 20).
         """
-        self.start = start_index
+        self.start_index = start_index
 
     def set_author(self, author):
         """Sets names that must be on the result's author list."""
@@ -657,7 +657,7 @@ class SearchScholarQuery(ScholarQuery):
                    'ylo': self.timeframe[0] or '',
                    'yhi': self.timeframe[1] or '',
                    'num': self.num_results or ScholarConf.MAX_PAGE_RESULTS,
-                   'start': self.start}
+                   'start': self.start_index}
 
         for key, val in urlargs.items():
             urlargs[key] = quote(str(val))
@@ -1066,7 +1066,7 @@ scholar.py -c 5 -a "albert einstein" -t --none "quantum theory" --after 1970"""
         if index + ScholarConf.MAX_PAGE_RESULTS > num_results:
             query.set_num_page_results(num_results - index)
 
-        query.set_start(index)
+        query.set_start_index(index)
 
         querier.send_query(query)
 


### PR DESCRIPTION
I noticed that the URL of Google Scholar's query URLs includes a `start` parameter, indicating the start index of the query.  By programmatically setting this parameter and looping until no more query results are returned, this modification will allow us to fetch lots more results than we could before.

I have noticed, however, that the tool quits after the first 1000 results, but it works great up until the 1000th item!  This limit does not appear to be a fault of scholar.py.  In a [sample search](http://scholar.google.com/scholar?start=980&q=%22ecosystem+services%22&hl=en&as_sdt=1,5&as_vis=1), Google Scholar will stop returning results after the 49th page (the 50th page is empty).

Thanks for this project!  It's been a huge help.
