### PR TITLE
fixed bug when passing unicode queries

### DIFF
--- a/scholar.py
+++ b/scholar.py
@@ -143,7 +143,11 @@ if sys.version_info[0] == 3:
     unicode = str # pylint: disable-msg=W0622
     encode = lambda s: s # pylint: disable-msg=C0103
 else:
-    encode = lambda s: s.encode('utf-8') # pylint: disable-msg=C0103
+    def encode(s):
+        if isinstance(s, (int, long, float, complex)):
+            return str(s)
+        else:
+            return s.encode('utf-8') # pylint: disable-msg=C0103
 
 
 class Error(Exception):
@@ -556,7 +560,7 @@ class ClusterScholarQuery(ScholarQuery):
                    'num': self.num_results or ScholarConf.MAX_PAGE_RESULTS}
 
         for key, val in urlargs.items():
-            urlargs[key] = quote(str(val))
+            urlargs[key] = quote(encode(val))
 
         return self.SCHOLAR_CLUSTER_URL % urlargs
 
@@ -650,7 +654,7 @@ class SearchScholarQuery(ScholarQuery):
                    'num': self.num_results or ScholarConf.MAX_PAGE_RESULTS}
 
         for key, val in urlargs.items():
-            urlargs[key] = quote(str(val))
+            urlargs[key] = quote(encode(val))
 
         return self.SCHOLAR_QUERY_URL % urlargs
 


### PR DESCRIPTION
This code:
```
# -*- coding: utf-8 -*-
from scholar import ScholarQuerier, SearchScholarQuery

querier = ScholarQuerier()
query = SearchScholarQuery()
query.set_phrase(u'Computer Vision – ACCV 2006')
querier.send_query(query)

print querier.articles
```
produces:
```
Traceback (most recent call last):
  File "scholar_unicode_bug.py", line 7, in <module>
    querier.send_query(query)
  File "scholar.py", line 810, in send_query
    html = self._get_http_response(url=query.get_url(),
  File "scholar.py", line 654, in get_url
    urlargs[key] = quote(str(val))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2013' in position 16: ordinal not in range(128)
```

The pull request solves the issue.