### PR TITLE
Search articles that cite a given cluster id

### DIFF
--- a/scholar.py
+++ b/scholar.py
@@ -576,6 +576,7 @@ class SearchScholarQuery(ScholarQuery):
         + '&as_publication=%(pub)s' \
         + '&as_ylo=%(ylo)s' \
         + '&as_yhi=%(yhi)s' \
+        + '&cites=%(cites_id)s' \
         + '&btnG=&hl=en&as_sdt=0,5&num=%(num)s'
 
     def __init__(self):
@@ -588,6 +589,7 @@ class SearchScholarQuery(ScholarQuery):
         self.author = None 
         self.pub = None
         self.timeframe = [None, None]
+        self.cites = None
 
     def set_words(self, words):
         """Sets words that *all* must be found in the result."""
@@ -630,12 +632,20 @@ class SearchScholarQuery(ScholarQuery):
         if end:
             end = ScholarUtils.ensure_int(end)
         self.timeframe = [start, end]
+    
+    def set_cites_id(self, cluster):
+        """
+        Sets a cluster ID that must be cited by results.
+        """
+        msg = 'cluster ID must be numeric'
+        self.cites = ScholarUtils.ensure_int(cluster, msg) 
 
     def get_url(self):
         if self.words is None and self.words_some is None \
            and self.words_none is None and self.phrase is None \
            and self.author is None and self.pub is None \
-           and self.timeframe[0] is None and self.timeframe[1] is None:
+           and self.timeframe[0] is None and self.timeframe[1] is None \
+           and self.cites is None:
             raise QueryArgumentError('search query needs more parameters')
 
         urlargs = {'words': self.words or '',
@@ -647,12 +657,16 @@ class SearchScholarQuery(ScholarQuery):
                    'pub': self.pub or '',
                    'ylo': self.timeframe[0] or '',
                    'yhi': self.timeframe[1] or '',
+                   'cites_id' : self.cites or '',
                    'num': self.num_results or ScholarConf.MAX_PAGE_RESULTS}
 
         for key, val in urlargs.items():
             urlargs[key] = quote(str(val))
 
-        return self.SCHOLAR_QUERY_URL % urlargs
+        if self.cites is None:
+            return self.SCHOLAR_QUERY_URL % urlargs
+        else:
+            return (self.SCHOLAR_QUERY_URL % urlargs) + "&scipsc=1" 
 
 
 class ScholarSettings(object):
@@ -953,6 +967,8 @@ scholar.py -c 5 -a "albert einstein" -t --none "quantum theory" --after 1970"""
                      help='Results must have appeared in or before given year')
     group.add_option('-C', '--cluster-id', metavar='CLUSTER_ID', default=None,
                      help='Do not search, just use articles in given cluster ID')
+    group.add_option('--cites', metavar='CLUSTER_ID', default=None,
+                     help='Searches all articles that cite a given cluster ID')
     group.add_option('-c', '--count', type='int', default=None,
                      help='Maximum number of results')
     parser.add_option_group(group)
@@ -1002,7 +1018,7 @@ scholar.py -c 5 -a "albert einstein" -t --none "quantum theory" --after 1970"""
     if options.cluster_id is not None:
         if options.author or options.allw or options.some or options.none \
            or options.phrase or options.title_only or options.pub \
-           or options.after or options.before:
+           or options.after or options.before or options.cites:
             print 'Cluster ID queries do not allow additional search arguments.'
             return 1
 
@@ -1043,6 +1059,8 @@ scholar.py -c 5 -a "albert einstein" -t --none "quantum theory" --after 1970"""
             query.set_pub(options.pub)
         if options.after or options.before:
             query.set_timeframe(options.after, options.before)
+        if options.cites:
+            query.set_cites_id(options.cites)
 
     if options.count is not None:
         options.count = min(options.count, ScholarConf.MAX_PAGE_RESULTS)


### PR DESCRIPTION
I added the option to search articles that cite a given cluster id. It seems to work fine.

In addition to the key "&cites", I also had to put the key/value "&scipsc=1". As I do not know was the second key means, it is only added for "cites" searches.
