### PR TITLE
Added export in JSON format

### DIFF
--- a/scholar.py
+++ b/scholar.py
@@ -7,6 +7,10 @@ page. It is not a recursive crawler.
 # ChangeLog
 # ---------
 #
+# 2.4.1: Additional features
+#
+#       - Added JSON as an option for export format
+#
 # 2.4:  Bugfixes:
 #
 #       - Correctly handle Unicode characters when reporting results
@@ -114,6 +118,7 @@ import optparse
 import os
 import sys
 import re
+import json
 
 try:
     # Try importing for Python 3
@@ -265,6 +270,9 @@ class ScholarArticle(object):
             res.append(sep.join(keys))
         res.append(sep.join([unicode(self.attrs[key][0]) for key in keys]))
         return '\n'.join(res)
+
+    def as_json(self):
+        return json.dumps(self.attrs)
 
     def as_citation(self):
         """
@@ -907,6 +915,13 @@ def csv(querier, header=False, sep='|'):
         print(encode(result))
         header = False
 
+def json_fmt(querier):
+    articles = querier.articles
+    lst = []
+    for art in articles:
+        lst.append(json.loads(art.as_json()))
+    print json.dumps(lst, sort_keys=True)
+
 def citation_export(querier):
     articles = querier.articles
     for art in articles:
@@ -965,6 +980,8 @@ scholar.py -c 5 -a "albert einstein" -t --none "quantum theory" --after 1970"""
                      help='Print article data in CSV form (separator is "|")')
     group.add_option('--csv-header', action='store_true',
                      help='Like --csv, but print header with column names')
+    group.add_option('--json', action='store_true',
+                     help='Print article data in JSON form')
     group.add_option('--citation', metavar='FORMAT', default=None,
                      help='Print article details in standard citation format. Argument Must be one of "bt" (BibTeX), "en" (EndNote), "rm" (RefMan), or "rw" (RefWorks).')
     parser.add_option_group(group)
@@ -1054,6 +1071,8 @@ scholar.py -c 5 -a "albert einstein" -t --none "quantum theory" --after 1970"""
         csv(querier)
     elif options.csv_header:
         csv(querier, header=True)
+    elif options.json:
+        json_fmt(querier)
     elif options.citation is not None:
         citation_export(querier)
     else:


### PR DESCRIPTION
I have added export in JSON format, which is useful if the scholar.py script is being used as a part of an automated workflow.
