### PR TITLE
JSON and JSONP output formats added.

### DIFF
--- a/scholar.py
+++ b/scholar.py
@@ -316,6 +316,15 @@ class ScholarArticle(object):
         res.append(sep.join([unicode(self.attrs[key][0]) for key in keys]))
         return '\n'.join(res)
 
+    def as_json(self, ensure_ascii=True, indent=None, separators=None, sort_keys=False):
+        """
+        Returns the results in JSON format. All the optional arguments are passed to json.dumps().
+        """
+        import json
+
+        d = dict([(key, self.attrs[key][0]) for key in self.attrs.keys()])
+        return json.dumps(d, ensure_ascii=ensure_ascii, indent=indent, separators=separators, sort_keys=sort_keys)
+
     def as_citation(self):
         """
         Reports the article in a standard citation format. This works only
@@ -1101,6 +1110,17 @@ def csv(querier, header=False, sep='|'):
         print(encode(result))
         header = False
 
+def json(querier, jsonp=None):
+    articles = querier.articles
+    result = '['
+    for art in articles:
+        result += art.as_json(indent=True) + ', '
+    result = result[:-2] + ']'
+    if jsonp:
+       print(encode(jsonp+'('+result+');'))
+    else:
+       print(encode(result))
+
 def citation_export(querier):
     articles = querier.articles
     for art in articles:
@@ -1165,6 +1185,10 @@ scholar.py -c 5 -a "albert einstein" -t --none "quantum theory" --after 1970"""
                      help='Print article data in CSV form (separator is "|")')
     group.add_option('--csv-header', action='store_true',
                      help='Like --csv, but print header with column names')
+    group.add_option('--json', action='store_true',
+                     help='Print article data in JSON form')
+    group.add_option('--jsonp', metavar='FUNC', default=None,
+                     help='Print article data in JSONP form, i.e. FUNC(JSON);')
     group.add_option('--citation', metavar='FORMAT', default=None,
                      help='Print article details in standard citation format. Argument Must be one of "bt" (BibTeX), "en" (EndNote), "rm" (RefMan), or "rw" (RefWorks).')
     parser.add_option_group(group)
@@ -1258,6 +1282,8 @@ scholar.py -c 5 -a "albert einstein" -t --none "quantum theory" --after 1970"""
         csv(querier)
     elif options.csv_header:
         csv(querier, header=True)
+    elif options.json:
+        json(querier, jsonp=options.jsonp)
     elif options.citation is not None:
         citation_export(querier)
     else:


### PR DESCRIPTION
I wrote it to be Python 2.6 compatible, which I found to be the (unstated) minimum version scholar.py runs with. If you're willing to raise the minimum version to 2.7, we could use OrderedDict for sorting the keys (not alphabetically, which json can do via sort_keys=True, but in the logical order). 2.7 would also allow us to simplify some other code and use argparse, which opens path to newer versions than Python 3.2.