### PR TITLE
Fixes TypeError: can't concat bytes to str (python3)

### DIFF
--- a/scholar.py
+++ b/scholar.py
@@ -1104,7 +1104,7 @@ def csv(querier, header=False, sep='|'):
 def citation_export(querier):
     articles = querier.articles
     for art in articles:
-        print(art.as_citation() + '\n')
+        print(art.as_citation().decode() + '\n') # Fix for "TypeError: can't concat bytes to str" error raised in python3
 
 
 def main():


### PR DESCRIPTION
Fixes error TypeError: can't concat bytes to str raised for result with --citation bt option, when using `python3`