### PR TITLE
Detect [PDF] link on the right hand side

### DIFF
--- a/scholar.py
+++ b/scholar.py
@@ -539,9 +539,14 @@ class ScholarArticleParser120726(ScholarArticleParser):
         for tag in div:
             if not hasattr(tag, 'name'):
                 continue
+
             if str(tag).lower().find('.pdf'):
                 if tag.find('div', {'class': 'gs_ttss'}):
                     self._parse_links(tag.find('div', {'class': 'gs_ttss'}))
+
+            sidetag = tag.find('div', {'class': 'gs_ttss'})
+            if sidetag and sidetag.a and str(sidetag).lower().find('[pdf]') >= 0:
+                self.article['url_pdf'] = self._path2url(sidetag.a['href'])
 
             if tag.name == 'div' and self._tag_has_class(tag, 'gs_ri'):
                 # There are (at least) two formats here. In the first


### PR DESCRIPTION
For some articles, there is an additional [PDF] link on the right hand side.

We could use that link as 'url_pdf' when the main article link is not a PDF file.