### PR TITLE
Encode log messages to avoid UnicodeEncodeError in Python2

### DIFF
--- a/scholar.py
+++ b/scholar.py
@@ -244,7 +244,7 @@ class ScholarUtils(object):
             return
         if ScholarUtils.LOG_LEVELS[level] > ScholarConf.LOG_LEVEL:
             return
-        sys.stderr.write('[%5s]  %s' % (level.upper(), msg + '\n'))
+        sys.stderr.write('[%5s]  %s' % (level.upper(), encode(msg) + '\n'))
         sys.stderr.flush()
 
 


### PR DESCRIPTION
To prevent the following error in Python 2:

    [ INFO]  results retrieval failed: 'ascii' codec can't encode character u'\u2014' in position 64784: ordinal not in range(128)

The error occurs in when redirect output to a file, redirect stderr to stdout, and set LOG_LEVEL to 'debug'.

    $ scholar.py --author "albert einstein" -dddd >result.txt 2>&1