### PR TITLE
Demo cluster command not working. Suggested fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Retrieve one article written by Einstein on quantum theory:
 
 Note the cluster ID in the above. Using this ID, you can directly access the cluster of articles Google Scholar has already determined to be variants of the same paper. So, let's see the versions:
 
-    $ scholar.py -C 17749203648027613321
+    $ scholar.py -c 19 -C 17749203648027613321
              Title On the quantum theory of radiation
                URL http://icole.mut-es.ac.ir/downloads/Sci_Sec/W1/Einstein%201917.pdf
          Citations 184


### PR DESCRIPTION
The example in the readme file does not work as the cluster is larger than 20, and does not return any results. Adding the “-c 19” returns the first 20 results.