### PR TITLE
decode binary string to ascii for citation export

### DIFF
--- a/scholar.py
+++ b/scholar.py
@@ -1142,7 +1142,7 @@ def csv(querier, header=False, sep='|'):
 def citation_export(querier):
     articles = querier.articles
     for art in articles:
-        print(art.as_citation() + '\n')
+        print(art.as_citation().decode('ascii'))
 
 
 def main():


### PR DESCRIPTION
before this change scholar.py would throw an error

```
TypeError: can't concat bytes to str
```

This is fixed simply by converting the binary string to ascii.

Also, the newline is no longer necessary.