### PR TITLE
Added extraction of url_pdf from right hand side [PDF] link.

### DIFF
--- a/scholar.py
+++ b/scholar.py
@@ -621,6 +621,11 @@ class ScholarArticleParser120726(ScholarArticleParser):
                         raw_text = raw_text.replace('\n', '')
                         self.article['excerpt'] = raw_text
 
+            if self.article['url_pdf'] is None and tag.name == 'div' and self._tag_has_class(tag, 'gs_ggs') \
+                    and tag.div and tag.div.div and tag.div.div.a and tag.div.div.a.span \
+                    and tag.div.div.a.span.get_text() == "[PDF]":
+                self.article['url_pdf'] = self._path2url(tag.div.div.a['href'])
+
 
 class ScholarQuery(object):
     """


### PR DESCRIPTION
This change will extract the `[PDF]` href value from the right hand side of a Google Scholar article entry. It will record the URL as `url_pdf` if the article's `url_pdf` hasn't already been filled and Google scholar labels the link as a PDF (i.e. the element's text is `[PDF]`).

**Test:**  `scholar.py -c 10 --txt --author "einstein" --phrase "quantum"`

Pre-change: **0/4 PDF links extracted**
Post-change: **4/4 PDF links extracted**

As far as I am aware Google Scholar's `[PDF]` label is the best, easily available indicator of whether the (optional) right hand side anchor refers to a PDF file.