### PR TITLE
Fixed Issue with https links

### DIFF
--- a/scholar.py
+++ b/scholar.py
@@ -512,7 +512,7 @@ class ScholarArticleParser(object):
 
     def _path2url(self, path):
         """Helper, returns full URL in case path isn't one."""
-        if path.startswith('http://'):
+        if path.startswith('http://') or path.startswith('https://'):
             return path
         if not path.startswith('/'):
             path = '/' + path


### PR DESCRIPTION
There's an issue with `_path2url(self, path)` which concats returned https links to http://scholar.google.com/.

For example:

```
$ python3 scholar.py --author "Margaret Fleck" | grep link.springer
           URL http://scholar.google.com/https://link.springer.com/chapter/10.1007/3-540-61123-1_173
           URL http://scholar.google.com/https://link.springer.com/article/10.1023/A:1008145029462
           URL http://scholar.google.com/https://link.springer.com/chapter/10.1007/3-540-61750-7_36
```

The actual url should be https://link.springer.com/chapter/10.1007/3-540-61750-7_36